### PR TITLE
Add Docker deployment and SmartSwitch gateway plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:8.1-apache
+
+# Install system dependencies and PHP extensions
+RUN apt-get update \
+    && apt-get install -y libzip-dev unzip \
+    && docker-php-ext-install pdo_mysql mysqli \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable Apache mod_rewrite
+RUN a2enmod rewrite
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+COPY . /var/www/html
+
+RUN composer install --no-interaction --prefer-dist --no-dev
+
+EXPOSE 80
+CMD ["apache2-foreground"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/var/www/html
+    environment:
+      DB_HOST: db
+      DB_USER: playsms
+      DB_PASS: playsms
+      DB_NAME: playsms
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: playsms
+      MYSQL_USER: playsms
+      MYSQL_PASSWORD: playsms
+      MYSQL_ROOT_PASSWORD: playsms
+    volumes:
+      - db_data:/var/lib/mysql
+volumes:
+  db_data:

--- a/web/plugin/gateway/smartswitch/config.php
+++ b/web/plugin/gateway/smartswitch/config.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * SmartSwitch gateway configuration
+ */
+defined('_SECURE_') or die('Forbidden');
+
+// gateway configuration in registry
+$reg = gateway_get_registry('smartswitch');
+
+$plugin_config['smartswitch'] = [
+    'name' => 'smartswitch',
+    'default_url' => 'https://api.smartswitch.example/message?login={SMARTSWITCH_USERNAME}&password={SMARTSWITCH_PASSWORD}&sender={SMARTSWITCH_SENDER}&to={SMARTSWITCH_TO}&text={SMARTSWITCH_MESSAGE}',
+    'url' => isset($reg['url']) && $reg['url'] ? $reg['url'] : $plugin_config['smartswitch']['default_url'],
+    'callback_url' => gateway_callback_url('smartswitch'),
+    'callback_authcode' => isset($reg['callback_authcode']) && $reg['callback_authcode'] ? $reg['callback_authcode'] : '',
+    'callback_access' => isset($reg['callback_access']) && $reg['callback_access'] ? $reg['callback_access'] : '',
+    'http_method' => isset($reg['http_method']) && (strtoupper($reg['http_method']) == 'GET' || strtoupper($reg['http_method']) == 'POST') ? strtoupper($reg['http_method']) : 'GET',
+    'api_username' => isset($reg['api_username']) ? $reg['api_username'] : '',
+    'api_password' => isset($reg['api_password']) ? $reg['api_password'] : '',
+    'module_sender' => isset($reg['module_sender']) ? $reg['module_sender'] : '',
+    'datetime_timezone' => isset($reg['datetime_timezone']) ? $reg['datetime_timezone'] : '',
+];
+
+$plugin_config['smartswitch']['_smsc_config_'] = [
+    'url' => _('SmartSwitch send SMS URL'),
+    'callback_authcode' => _('Callback authcode'),
+    'callback_access' => _('Callback access'),
+    'http_method' => _('HTTP method'),
+    'api_username' => _('API username'),
+    'api_password' => _('API password'),
+    'module_sender' => _('Module sender ID'),
+    'datetime_timezone' => _('Module timezone'),
+];
+

--- a/web/plugin/gateway/smartswitch/fn.php
+++ b/web/plugin/gateway/smartswitch/fn.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SmartSwitch gateway functions
+ */
+defined('_SECURE_') or die('Forbidden');
+
+function smartswitch_hook_sendsms($smsc, $sms_sender, $sms_footer, $sms_to, $sms_msg, $uid = 0, $gpid = 0, $smslog_id = 0, $sms_type = 'text', $unicode = 0)
+{
+    global $plugin_config;
+
+    $plugin_config = gateway_apply_smsc_config($smsc, $plugin_config);
+
+    $module_sender = isset($plugin_config['smartswitch']['module_sender']) && core_sanitize_sender($plugin_config['smartswitch']['module_sender']) ? core_sanitize_sender($plugin_config['smartswitch']['module_sender']) : '';
+    $sms_sender = $module_sender ?: core_sanitize_sender($sms_sender);
+    $sms_to = core_sanitize_mobile($sms_to);
+    $sms_footer = core_sanitize_footer($sms_footer);
+    $sms_msg = stripslashes($sms_msg . $sms_footer);
+
+    _log("enter smsc:" . $smsc . " smslog_id:" . $smslog_id . " uid:" . $uid . " from:" . $sms_sender . " to:" . $sms_to, 3, "smartswitch_hook_sendsms");
+
+    if ($sms_sender && $sms_to && $sms_msg) {
+        $unicode_query_string = '';
+        if ($unicode && function_exists('mb_convert_encoding')) {
+            $sms_msg = mb_convert_encoding($sms_msg, "UCS-2", "auto");
+            $unicode_query_string = "&coding=8";
+        }
+
+        $url = htmlspecialchars_decode($plugin_config['smartswitch']['url'] . $unicode_query_string);
+        $url = str_replace('{SMARTSWITCH_USERNAME}', urlencode($plugin_config['smartswitch']['api_username']), $url);
+        $url = str_replace('{SMARTSWITCH_PASSWORD}', urlencode($plugin_config['smartswitch']['api_password']), $url);
+        $url = str_replace('{SMARTSWITCH_SENDER}', urlencode($sms_sender), $url);
+        $url = str_replace('{SMARTSWITCH_TO}', urlencode($sms_to), $url);
+        $url = str_replace('{SMARTSWITCH_MESSAGE}', urlencode($sms_msg), $url);
+        $url = str_replace('{SMARTSWITCH_CALLBACK_URL}', urlencode($plugin_config['smartswitch']['callback_url']), $url);
+
+        $response = core_get_contents($url, $plugin_config['smartswitch']['http_method']);
+        $resp = preg_split('/\s+/', trim($response));
+        if (isset($resp[0]) && $resp[0] !== '') {
+            $remote_id = $resp[0];
+            if (dba_update(_DB_PREF_ . '_tblSMSOutgoing', ['remote_id' => $remote_id], ['smslog_id' => $smslog_id, 'flag_deleted' => 0])) {
+                $p_status = 1;
+                dlr($smslog_id, $uid, $p_status);
+            } else {
+                $p_status = 0;
+                dlr($smslog_id, $uid, $p_status);
+            }
+            return true;
+        }
+
+        _log("failed smslog_id:" . $smslog_id . " response:[" . $response . "] smsc:" . $smsc, 2, "smartswitch_hook_sendsms");
+    }
+
+    $p_status = 2;
+    dlr($smslog_id, $uid, $p_status);
+    return false;
+}

--- a/web/plugin/gateway/smartswitch/index.html
+++ b/web/plugin/gateway/smartswitch/index.html
@@ -1,0 +1,1 @@
+Forbidden

--- a/web/plugin/gateway/smartswitch/smartswitch.php
+++ b/web/plugin/gateway/smartswitch/smartswitch.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * SmartSwitch gateway administration
+ */
+defined('_SECURE_') or die('Forbidden');
+
+if (!auth_isadmin()) {
+    auth_block();
+}
+
+include $core_config['apps_path']['plug'] . "/gateway/smartswitch/config.php";
+
+switch (_OP_) {
+    case "manage":
+        $tpl = [
+            'name' => 'smartswitch',
+            'vars' => [
+                'DIALOG_DISPLAY' => _dialog(),
+                'Manage' => _('Manage'),
+                'Gateway' => _('Gateway'),
+                'SmartSwitch send SMS URL' => _mandatory(_('SmartSwitch send SMS URL')),
+                'Callback URL' => _('Callback URL'),
+                'Callback authcode' => _('Callback authcode'),
+                'Callback access' => _('Callback access'),
+                'HTTP method' => _('HTTP method'),
+                'API username' => _('API username'),
+                'API password' => _('API password'),
+                'Module sender ID' => _('Module sender ID'),
+                'Module timezone' => _('Module timezone'),
+                'Save' => _('Save'),
+                'Notes' => _('Notes'),
+                'HINT_CALLBACK_URL' => _hint(_('Empty callback URL to set default')),
+                'HINT_CALLBACK_AUTHCODE' => _hint(_('Fill with at least 16 alphanumeric authentication code to secure callback URL')),
+                'HINT_CALLBACK_ACCESS' => _hint(_('Fill with IP addresses (separated by comma) to limit access to callback URL')),
+                'HINT_HTTP_METHOD' => _hint(_('Select which HTTP method will be used to submit requests')),
+                'HINT_FILL_PASSWORD' => _hint(_('Fill to change the API password')),
+                'HINT_MODULE_SENDER' => _hint(_('Max. 16 numeric or 11 alphanumeric char. empty to disable')),
+                'HINT_TIMEZONE' => _hint(_('Eg: +0700 for UTC+7 or Jakarta/Bangkok timezone')),
+                'CALLBACK_URL_ACCESSIBLE' => _('Your callback URL must be accessible from IP addresses listed in callback access'),
+                'CALLBACK_AUTHCODE' => sprintf(_('You have to include callback authcode as query parameter %s'), ': <strong>authcode</strong>'),
+                'CALLBACK_ACCESS' => _('Your callback requests must be coming from IP addresses listed in callback access'),
+                'REMOTE_PUSH_DLR' => _('Remote gateway or callback server will push DLR and incoming SMS to your callback URL'),
+                'BUTTON_BACK' => _back('index.php?app=main&inc=core_gateway&op=gateway_list'),
+                'gateway_name' => $plugin_config['smartswitch']['name'],
+                'url' => $plugin_config['smartswitch']['url'],
+                'callback_url' => gateway_callback_url('smartswitch'),
+                'callback_authcode' => $plugin_config['smartswitch']['callback_authcode'],
+                'callback_access' => $plugin_config['smartswitch']['callback_access'],
+                'http_method' => $plugin_config['smartswitch']['http_method'],
+                'api_username' => $plugin_config['smartswitch']['api_username'],
+                'module_sender' => $plugin_config['smartswitch']['module_sender'],
+                'datetime_timezone' => $plugin_config['smartswitch']['datetime_timezone']
+            ]
+        ];
+        _p(tpl_apply($tpl));
+        break;
+
+    case "manage_save":
+        $url = isset($_REQUEST['url']) && $_REQUEST['url'] ? $_REQUEST['url'] : $plugin_config['smartswitch']['default_url'];
+        $callback_url = gateway_callback_url('smartswitch');
+        $callback_authcode = isset($_REQUEST['callback_authcode']) && core_sanitize_alphanumeric($_REQUEST['callback_authcode']) ? core_sanitize_alphanumeric($_REQUEST['callback_authcode']) : '';
+        $callback_access = isset($_REQUEST['callback_access']) ? preg_replace('/[^0-9a-zA-Z\.,_\-\/]+/', '', trim($_REQUEST['callback_access'])) : '';
+        $callback_access = preg_replace('/[,]+/', ',', $callback_access);
+        $http_method = $_REQUEST['http_method'] ?? 'GET';
+        $http_method = strtoupper($http_method) == 'GET' || strtoupper($http_method) == 'POST' ? strtoupper($http_method) : 'GET';
+        $api_username = $_REQUEST['api_username'];
+        $api_password = $_REQUEST['api_password'];
+        $module_sender = core_sanitize_sender($_REQUEST['module_sender']);
+        $datetime_timezone = $_REQUEST['datetime_timezone'];
+        if ($url) {
+            $items = [
+                'url' => $url,
+                'callback_url' => $callback_url,
+                'callback_authcode' => $callback_authcode,
+                'callback_access' => $callback_access,
+                'http_method' => $http_method,
+                'api_username' => $api_username,
+                'module_sender' => $module_sender,
+                'datetime_timezone' => $datetime_timezone
+            ];
+            if ($api_password) {
+                $items['api_password'] = $api_password;
+            }
+            if (registry_update(0, 'gateway', 'smartswitch', $items)) {
+                $_SESSION['dialog']['info'][] = _('Gateway module configurations has been saved');
+            } else {
+                $_SESSION['dialog']['danger'][] = _('Fail to save gateway module configurations');
+            }
+        } else {
+            $_SESSION['dialog']['danger'][] = _('All mandatory fields must be filled');
+        }
+        header("Location: " . _u('index.php?app=main&inc=gateway_smartswitch&op=manage'));
+        exit();
+}

--- a/web/plugin/gateway/smartswitch/templates/smartswitch.html
+++ b/web/plugin/gateway/smartswitch/templates/smartswitch.html
@@ -1,0 +1,75 @@
+{{ DIALOG_DISPLAY }}
+<h2>{{ Manage }} {{ gateway_name }}</h2>
+<form action=index.php?app=main&inc=gateway_smartswitch&op=manage_save method=post>
+	{{ CSRF_FORM }}
+	<table class=playsms-table>
+		<tbody>
+			<tr>
+				<td class=label-sizer>{{ Gateway }}</td>
+				<td>{{ gateway_name }}</td>
+			</tr>
+			<tr>
+                                <td>{{ SmartSwitch send SMS URL }}</td>
+				<td><input type=text maxlength=255 name=url value="{{ url }}"></td>
+			</tr>
+			<tr>
+				<td>{{ Callback URL }}</td>
+				<td>
+					<span>{{ callback_url }}</span>
+				</td>
+			</tr>
+			<tr>
+				<td>{{ Callback authcode }}</td>
+				<td>
+					<input type=text maxlength=255 name=callback_authcode value="{{ callback_authcode }}">
+					{{ HINT_CALLBACK_AUTHCODE }}
+				</td>
+			</tr>
+			<tr>
+				<td>{{ Callback access }}</td>
+				<td>
+					<input type=text maxlength=255 name=callback_access value="{{ callback_access }}">
+					{{ HINT_CALLBACK_ACCESS }}
+				</td>
+			</tr>
+			<tr>
+				<td>{{ HTTP method }}</td>
+				<td>
+					<input type=text size=4 maxlength=4 name=http_method value="{{ http_method }}">
+					{{ HINT_HTTP_METHOD }}
+				</td>
+			</tr>
+			<tr>
+				<td>{{ API username }}</td>
+				<td><input type=text maxlength=255 name=api_username value="{{ api_username }}"></td>
+			</tr>
+			<tr>
+				<td>{{ API password }}</td>
+				<td><input type=password maxlength=255 name=api_password value=""> {{ HINT_FILL_PASSWORD }}</td>
+			</tr>
+			<tr>
+				<td>{{ Module sender ID }}</td>
+				<td>
+					<input type=text size=16 maxlength=16 name=module_sender value="{{ module_sender }}">
+					{{ HINT_MODULE_SENDER }}
+				</td>
+			</tr>
+			<tr>
+				<td>{{ Module timezone }}</td>
+				<td>
+					<input type=text size=5 maxlength=5 name=datetime_timezone value="{{ datetime_timezone }}">
+					{{ HINT_TIMEZONE }}
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<p><input type=submit class=button value="{{ Save }}">
+</form>
+<p>
+	{{ Notes }}:<br />
+	- {{ REMOTE_PUSH_DLR }}<br />
+	- {{ CALLBACK_URL_ACCESSIBLE }}<br />
+	- {{ CALLBACK_AUTHCODE }}<br />
+	- {{ CALLBACK_ACCESS }}<br />
+</p>
+<p>{{ BUTTON_BACK }}</p>


### PR DESCRIPTION
## Summary
- containerize playSMS with Docker and docker-compose
- add SmartSwitch gateway plugin for sending SMS via SmartSwitch API

## Testing
- `php -l web/plugin/gateway/smartswitch/config.php`
- `php -l web/plugin/gateway/smartswitch/fn.php`
- `php -l web/plugin/gateway/smartswitch/smartswitch.php`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b258b36483338815bec21480e68e